### PR TITLE
Add react-native dependency to resolve it correctly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "ern-composite",
   "version": "0.0.1",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "react-native": "0.66.4"
+  }
 }


### PR DESCRIPTION
Add react-native package to dependencies to get the metro bundler to resolve the react-native CLI tool correctly: https://github.com/facebook/metro/blob/main/packages/metro-resolver/src/resolve.js#L137

This is also already included in the default non-base composites automatically:
https://github.com/electrode-io/electrode-native/blob/master/ern-composite-gen/src/GeneratedComposite.ts#L77

Failure to include the dependency will result in ambiguity in finding the right react-native CLI tool to run.